### PR TITLE
Add v2 endpoint for historic aggregates

### DIFF
--- a/lib/alpaca-trade-api.js
+++ b/lib/alpaca-trade-api.js
@@ -57,6 +57,7 @@ Alpaca.prototype.getSymbolTypeMap = polygon.symbolTypeMap
 Alpaca.prototype.getHistoricTrades = polygon.historicTrades
 Alpaca.prototype.getHistoricQuotes = polygon.historicQuotes
 Alpaca.prototype.getHistoricAggregates = polygon.historicAggregates
+Alpaca.prototype.getHistoricAggregatesV2 = polygon.historicAggregatesV2
 Alpaca.prototype.getLastTrade = polygon.lastTrade
 Alpaca.prototype.getLastQuote = polygon.lastQuote
 Alpaca.prototype.getConditionMap = polygon.conditionMap

--- a/lib/api.js
+++ b/lib/api.js
@@ -35,7 +35,7 @@ function dataHttpRequest(endpoint, queryParams, body, method) {
   })
 }
 
-function polygonHttpRequest(endpoint, queryParams, body, method) {
+function polygonHttpRequest(endpoint, queryParams, body, method, apiVersion = 'v1') {
   const { baseUrl, keyId, polygonBaseUrl } = this.configuration
   queryParams = queryParams || {}
   queryParams['apiKey'] = keyId
@@ -44,7 +44,7 @@ function polygonHttpRequest(endpoint, queryParams, body, method) {
   }
   return request({
     method: method || 'GET',
-    uri: joinUrl(polygonBaseUrl, 'v1', endpoint),
+    uri: joinUrl(polygonBaseUrl, apiVersion, endpoint),
     qs: queryParams || {},
     headers: {
       'content-type': 'application/json',

--- a/lib/resources/polygon.js
+++ b/lib/resources/polygon.js
@@ -34,7 +34,7 @@ function historicAggregates(size, symbol, options = {}) {
 // options: unadjusted
 function historicAggregatesV2(symbol, multiplier, size, from, to, options = {}) {
   const path = `/aggs/ticker/${symbol}/range/${multiplier}/${size}/${from}/${to}`
-  return this.polygonHttpRequest(path, options, apiVersion = 'v2')
+  return this.polygonHttpRequest(path, options, null, null, 'v2')
 }
 
 function lastTrade(symbol) {

--- a/lib/resources/polygon.js
+++ b/lib/resources/polygon.js
@@ -11,21 +11,29 @@ function symbolTypeMap() {
 }
 
 // options: limit, offset
-function historicTrades(symbol, date, options={}) {
+function historicTrades(symbol, date, options = {}) {
   const path = `/historic/trades/${symbol}/${toDateString(date)}`
   return this.polygonHttpRequest(path, options)
 }
 
 // options: limit, offset
-function historicQuotes(symbol, date, options={}) {
+function historicQuotes(symbol, date, options = {}) {
   const path = `/historic/quotes/${symbol}/${toDateString(date)}`
   return this.polygonHttpRequest(path, options)
 }
 
 // size: 'day', 'minute'
 // options: from, to, limit, unadjusted
-function historicAggregates(size, symbol, options={}) {
+function historicAggregates(size, symbol, options = {}) {
   const path = `/historic/agg/${size}/${symbol}`
+  return this.polygonHttpRequest(path, options)
+}
+
+// size: 'day', 'minute'
+// from, to: YYYY-MM-DD or unix millisecond timestamps
+// options: unadjusted
+function historicAggregatesV2(symbol, multiplier, size, from, to, options = {}) {
+  const path = `/aggs/ticker/${symbol}/range/${multiplier}/${size}/${from}/${to}`
   return this.polygonHttpRequest(path, options)
 }
 
@@ -44,7 +52,7 @@ function conditionMap(ticktype = 'trades') {
   return this.polygonHttpRequest(path)
 }
 
-const symbolMeta = (resource) => function(symbol) {
+const symbolMeta = (resource) => function (symbol) {
   const path = `/meta/symbols/${symbol}` + (resource ? `/${resource}` : '')
   return this.polygonHttpRequest(path)
 }
@@ -64,6 +72,7 @@ module.exports = {
   historicTrades,
   historicQuotes,
   historicAggregates,
+  historicAggregatesV2,
   lastTrade,
   lastQuote,
   conditionMap,

--- a/lib/resources/polygon.js
+++ b/lib/resources/polygon.js
@@ -34,7 +34,7 @@ function historicAggregates(size, symbol, options = {}) {
 // options: unadjusted
 function historicAggregatesV2(symbol, multiplier, size, from, to, options = {}) {
   const path = `/aggs/ticker/${symbol}/range/${multiplier}/${size}/${from}/${to}`
-  return this.polygonHttpRequest(path, options)
+  return this.polygonHttpRequest(path, options, apiVersion = 'v2')
 }
 
 function lastTrade(symbol) {

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -74,6 +74,10 @@ const socket = paca.websocket;
     limit: 2,
     unadjusted: false,
   }))
+  console.log(await paca.getHistoricAggregatesV2(
+    'AAPL', 1, 'day', new Date('December 1 2018'), new Date('December 5 2018'), {
+      unadjusted: false,
+    }))
   console.log(await paca.getLastTrade('AAPL'))
   console.log(await paca.getLastQuote('AAPL'))
   console.log(await paca.getConditionMap())

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -77,7 +77,8 @@ const socket = paca.websocket;
   console.log(await paca.getHistoricAggregatesV2(
     'AAPL', 1, 'day', new Date('December 1 2018'), new Date('December 5 2018'), {
       unadjusted: false,
-    }))
+    }
+  ))
   console.log(await paca.getLastTrade('AAPL'))
   console.log(await paca.getLastQuote('AAPL'))
   console.log(await paca.getConditionMap())

--- a/test/resources/polygon.test.js
+++ b/test/resources/polygon.test.js
@@ -51,6 +51,14 @@ describe('polygon methods', () => {
     ).to.eventually.have.property('aggType')
   })
 
+  it('can get historic aggregates v2', () => {
+    return expect(
+      alpaca.getHistoricAggregatesV2('AAPL', 1, 'day', '2018-02-01', '2018-02-10', {
+        unadjusted: false,
+      })
+    ).to.eventually.have.property('queryCount')
+  })
+
   it('can get historic trades', () => {
     return expect(
       alpaca.getHistoricTrades('AAPL', '2018-3-2', { offset: 2, limit: 12 })

--- a/test/support/mock-polygon.js
+++ b/test/support/mock-polygon.js
@@ -155,7 +155,11 @@ module.exports = function createPolygonMock() {
     throw apiError(404, 'route not found')
   }))
 
-  return express.Router().use('/v1', v1).use('v2', v2)
+  v2.use(apiMethod(() => {
+    throw apiError(404, 'route not found')
+  }))
+
+  return express.Router().use('/v1', v1).use('/v2', v2)
 }
 
 const symbolEntity = {


### PR DESCRIPTION
Polygon's v2 aggregate endpoint is more stable than the v1 endpoint. Eventually, the v2 endpoint will replace the v1 endpoint entirely. Though a timeframe for this has not been given, users are still encouraged to move to the v2 historic aggregate methods. 