### PR TITLE
Update default Alpaca API version used from v1 to v2

### DIFF
--- a/lib/alpaca-trade-api.js
+++ b/lib/alpaca-trade-api.js
@@ -22,6 +22,7 @@ function Alpaca(config = {}) {
     polygonBaseUrl: config.polygonBaseUrl || process.env.POLYGON_API_BASE_URL || 'https://api.polygon.io',
     keyId: config.keyId || process.env.APCA_API_KEY_ID || '',
     secretKey: config.secretKey || process.env.APCA_API_SECRET_KEY || '',
+    apiVersion: config.apiVersion || process.env.APCA_API_VERSION || 'v2',
   }
   this.websocket = new websockets.AlpacaStreamClient({
     url: this.configuration.baseUrl,

--- a/lib/api.js
+++ b/lib/api.js
@@ -4,10 +4,10 @@ const request = require('request-promise')
 const joinUrl = require('urljoin')
 
 function httpRequest(endpoint, queryParams, body, method) {
-  const { baseUrl, keyId, secretKey } = this.configuration
+  const { baseUrl, keyId, secretKey, apiVersion } = this.configuration
   return request({
     method: method || 'GET',
-    uri: joinUrl(baseUrl, 'v1', endpoint),
+    uri: joinUrl(baseUrl, apiVersion, endpoint),
     qs: queryParams || {},
     headers: {
       'content-type': method !== 'DELETE' ? 'application/json' : undefined,


### PR DESCRIPTION
The old version can be specified by setting the environment variable `APCA_API_VERSION` to `v1`.