### PR TITLE
Add OAuth configuration options

### DIFF
--- a/lib/alpaca-trade-api.js
+++ b/lib/alpaca-trade-api.js
@@ -23,11 +23,13 @@ function Alpaca(config = {}) {
     keyId: config.keyId || process.env.APCA_API_KEY_ID || '',
     secretKey: config.secretKey || process.env.APCA_API_SECRET_KEY || '',
     apiVersion: config.apiVersion || process.env.APCA_API_VERSION || 'v2',
+    oauth: config.oauth || process.env.APCA_API_OAUTH || '',
   }
   this.websocket = new websockets.AlpacaStreamClient({
     url: this.configuration.baseUrl,
     apiKey: this.configuration.keyId,
-    secretKey: this.configuration.secretKey
+    secretKey: this.configuration.secretKey,
+    oauth: this.configuration.oauth
   })
   this.websocket.STATE = websockets.STATE
   this.websocket.EVENT = websockets.EVENT

--- a/lib/api.js
+++ b/lib/api.js
@@ -4,16 +4,19 @@ const request = require('request-promise')
 const joinUrl = require('urljoin')
 
 function httpRequest(endpoint, queryParams, body, method) {
-  const { baseUrl, keyId, secretKey, apiVersion } = this.configuration
+  const { baseUrl, keyId, secretKey, apiVersion, oauth } = this.configuration
   return request({
     method: method || 'GET',
     uri: joinUrl(baseUrl, apiVersion, endpoint),
     qs: queryParams || {},
-    headers: {
+    headers: oauth !== '' ? {
       'content-type': method !== 'DELETE' ? 'application/json' : undefined,
-      'APCA-API-KEY-ID': keyId,
-      'APCA-API-SECRET-KEY': secretKey,
-    },
+      'Authorization': "Bearer " + oauth,
+    } : {
+        'content-type': method !== 'DELETE' ? 'application/json' : undefined,
+        'APCA-API-KEY-ID': keyId,
+        'APCA-API-SECRET-KEY': secretKey,
+      },
     body: body || undefined,
     json: true,
   })
@@ -25,11 +28,14 @@ function dataHttpRequest(endpoint, queryParams, body, method) {
     method: method || 'GET',
     uri: joinUrl(dataBaseUrl, 'v1', endpoint),
     qs: queryParams || {},
-    headers: {
+    headers: oauth !== '' ? {
       'content-type': method !== 'DELETE' ? 'application/json' : undefined,
-      'APCA-API-KEY-ID': keyId,
-      'APCA-API-SECRET-KEY': secretKey,
-    },
+      'Authorization': "Bearer " + oauth,
+    } : {
+        'content-type': method !== 'DELETE' ? 'application/json' : undefined,
+        'APCA-API-KEY-ID': keyId,
+        'APCA-API-SECRET-KEY': secretKey,
+      },
     body: body || undefined,
     json: true,
   })

--- a/lib/resources/polygonWebsocket.js
+++ b/lib/resources/polygonWebsocket.js
@@ -119,7 +119,7 @@ class PolygonWebsocket extends events.EventEmitter {
             }
             this.connect()
         }, this.session.reconnectTimeout * 1000)
-        this.emit(STATE.WAITING_TO_RECONNECT, this.session.reconnectTimeout)
+        this.emit(websockets.STATE.WAITING_TO_RECONNECT, this.session.reconnectTimeout)
     }
 }
 

--- a/lib/resources/position.js
+++ b/lib/resources/position.js
@@ -13,7 +13,7 @@ function closeAll() {
 }
 
 function closeOne(symbol) {
-  return this.httpRequest('/positions' + symbol, null, null, 'DELETE')
+  return this.httpRequest('/positions/' + symbol, null, null, 'DELETE')
 }
 
 module.exports = {

--- a/lib/resources/websockets.js
+++ b/lib/resources/websockets.js
@@ -165,22 +165,6 @@ class AlpacaStreamClient extends events.EventEmitter {
     })
   }
 
-  unsubscribe(keys) {
-    keys.forEach(x => {
-      delete this.subscriptionState[x]
-    })
-    remains = Object.keys(this.subscriptionState)
-    const subMsg = {
-      action: 'listen',
-      data: {
-        streams: remains
-      }
-    }
-    if (remains.length > 0) {
-      this.send(JSON.stringify(subMsg))
-    }
-  }
-
   subscriptions() {
     return Object.keys(this.subscriptionState)
   }

--- a/lib/resources/websockets.js
+++ b/lib/resources/websockets.js
@@ -73,10 +73,10 @@ class AlpacaStreamClient extends events.EventEmitter {
     this.session = Object.assign(this.defaultOptions, opts)
 
     this.session.url = this.session.url.replace(/^http/, "ws") + "/stream"
-    if (this.session.apiKey.length === 0) {
+    if (this.session.apiKey.length === 0 && this.session.oauth.length === 0) {
       throw new Error(ERROR.MISSING_API_KEY)
     }
-    if (this.session.secretKey.length === 0) {
+    if (this.session.secretKey.length === 0 && this.session.oauth.length === 0) {
       throw new Error(ERROR.MISSING_SECRET_KEY)
     }
     // Keep track of subscriptions in case we need to reconnect after the client


### PR DESCRIPTION
Alpaca will be adding OAuth support on a limited basis, and this allows for REST API authorization with OAuth using a different header. Websocket authentication with OAuth is not yet available.