### PR TITLE
Send channel list when reconnecting

### DIFF
--- a/lib/resources/polygonWebsocket.js
+++ b/lib/resources/polygonWebsocket.js
@@ -12,8 +12,10 @@ class PolygonWebsocket extends events.EventEmitter {
         this._apiKey = apiKey
         this.session = session
         this.connectCalled = false
+        this.channels = []
     }
     connect(initialChannels) {
+        this.channels = initialChannels
         this.reconnectDisabled = false
         this.connectCalled = true
         this.emit(websockets.STATE.CONNECTING)
@@ -93,13 +95,16 @@ class PolygonWebsocket extends events.EventEmitter {
             params: topics.join(',')
         }
         this.send(JSON.stringify(subMsg))
+        this.channels = this.channels.concat(topics)
     }
     unsubscribe(topics) {
         const subMsg = {
             action: 'unsubscribe',
-            params: topics
+            params: topics.join(',')
         }
+        console.log(JSON.stringify(subMsg))
         this.send(JSON.stringify(subMsg))
+        this.channels = this.channels.filter(e => topics.indexOf(e) == -1)
     }
     close() {
         this.connectCalled = false
@@ -117,7 +122,7 @@ class PolygonWebsocket extends events.EventEmitter {
                     this.session.reconnectTimeout = this.session.maxReconnectTimeout
                 }
             }
-            this.connect()
+            this.connect(this.channels)
         }, this.session.reconnectTimeout * 1000)
         this.emit(websockets.STATE.WAITING_TO_RECONNECT, this.session.reconnectTimeout)
     }

--- a/lib/resources/websockets.js
+++ b/lib/resources/websockets.js
@@ -137,6 +137,14 @@ class AlpacaStreamClient extends events.EventEmitter {
     this.polygon.connect(channels)
   }
 
+  _unsubscribe_polygon(channels) {
+    if (this.polygon.connectCalled) {
+      if (channels) {
+        this.polygon.unsubscribe(channels)
+      }
+    }
+  }
+
   subscribe(keys) {
     let wsChannels = []
     let polygonChannels = []
@@ -166,6 +174,24 @@ class AlpacaStreamClient extends events.EventEmitter {
     })
   }
 
+  unsubscribe(keys) {
+    // Currently, only Polygon channels can be unsubscribed from
+    let polygonChannels = []
+    keys.forEach(key => {
+      const poly = ['Q.', 'T.', 'A.', 'AM.']
+      let found = poly.filter((channel) => key.startsWith(channel))
+      if (found.length > 0) {
+        polygonChannels.push(key)
+      }
+    })
+    if (polygonChannels.length > 0) {
+      this._unsubscribe_polygon(polygonChannels)
+    }
+    keys.forEach(x => {
+      this.subscriptionState[x] = false
+    })
+  }
+
   subscriptions() {
     return Object.keys(this.subscriptionState)
   }
@@ -192,6 +218,14 @@ class AlpacaStreamClient extends events.EventEmitter {
 
   onAccountUpdate(fn) {
     this.on(EVENT.ACCOUNT_UPDATE, accountUpdate => fn(accountUpdate))
+  }
+
+  onPolygonConnect(fn) {
+    this.polygon.on(STATE.CONNECTED, () => fn())
+  }
+
+  onPolygonDisconnect(fn) {
+    this.polygon.on(STATE.DISCONNECTED, () => fn())
   }
 
   onStockTrades(fn) {

--- a/test/alpaca-trade-api.test.js
+++ b/test/alpaca-trade-api.test.js
@@ -14,6 +14,7 @@ describe('alpaca-trade-api', function () {
         polygonBaseUrl: 'https://polygon.example.com',
         keyId: 'test_id',
         secretKey: 'test_secret',
+        oauth: '',
       }
       const alpaca = new Alpaca(testConfig)
       expect(alpaca.configuration).to.deep.equal(testConfig)


### PR DESCRIPTION
A channel list was not being passed to Polygon during reconnection. This tracks the list of subscribed channels and attempts to reconnect with the existing channel list.