### PR TITLE
Fixed error reading bar close price

### DIFF
--- a/examples/mean-reversion.js
+++ b/examples/mean-reversion.js
@@ -138,10 +138,10 @@ class MeanReversion {
     await this.alpaca.getBars('minute', this.stock,{limit: 20}).then((resp) => {
       bars = resp[this.stock];
     }).catch((err) => {console.log(err.error);});
-    var currPrice = bars[bars.length - 1].c;
+    var currPrice = bars[bars.length - 1].closePrice;
     this.runningAverage = 0;
     bars.forEach((bar) => {
-      this.runningAverage += bar.c;
+      this.runningAverage += bar.closePrice;
     })
     this.runningAverage /= 20;
   


### PR DESCRIPTION
The script wasn't reading the close price. Looks like the correct variable name is "bar.closePrice" instead of just "bar.c"