### PR TITLE
Update readme to use getAccountActivities

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ updateAccountConfigurations(AccountConfigurations) => Promise<AccountConfigurati
 Calls `GET /account/activities` and returns account actvities.
 
 ```ts
-getActivities({
+getAccountActivities({
   activityTypes: string | string[], // Any valid activity type
   until: Date,
   after: Date,


### PR DESCRIPTION
the sdk is using getAccountActivities which points internally to getActivities