### PR TITLE
Handle cancel errors + corrections

### DIFF
--- a/lib/resources/datav2/entityv2.ts
+++ b/lib/resources/datav2/entityv2.ts
@@ -187,6 +187,86 @@ export interface RawLuld {
   z: string;
 }
 
+const cancel_error_mapping_v2 = {
+  S: "Symbol",
+	i: "ID",
+	x: "Exchange",
+	p: "Price",
+	s: "Size",
+	a: "CancelErrorAction",
+	z: "Tape",
+	t: "Timestamp",
+};
+
+export interface AlpacaCancelError {
+  Symbol: string;
+  ID: number;
+  Exchange: string;
+  Price: number;
+  Size: number;
+  CancelErrorAction: string;
+  Tape: string;
+  Timestamp: string;
+}
+
+export interface RawCancelError {
+  T: string;
+  S: string;
+  i: number;
+  x: string;
+  p: number;
+  s: number;
+  a: string;
+  z: string;
+  t: string;
+}
+
+const correction_mapping_v2 = {
+  S: "Symbol",
+	x: "Exchange",
+	oi: "OriginalID",
+	op: "OriginalPrice",
+	os: "OriginalSize",
+	oc: "OriginalConditions",
+	ci: "CorrectedID",
+	cp: "CorrectedPrice",
+	cs: "CorrectedSize",
+	cc: "CorrectedConditions",
+	z: "Tape",
+	t: "Timestamp",
+};
+
+export interface AlpacaCorrection {
+  Symbol: string;
+  Exchange: string;
+  OriginalID: number;
+  OriginalPrice: number;
+  OriginalSize: number;
+  OriginalConditions: Array<string>;
+  CorrectedID: number;
+  CorrectedPrice: number;
+  CorrectedSize: number;
+  CorrectedConditions: Array<string>;
+  Tape: string;
+  Timestamp: string;
+}
+
+export interface RawCorrection {
+  T: string;
+  S: string;
+  x: string;
+  oi: number;
+  op: number;
+  os: number;
+  oc: Array<string>;
+  ci: number;
+  cp: number;
+  cs: number;
+  cc: Array<string>;
+  z: string;
+  t: string;
+}
+
 const crypto_trade_mapping = {
   S: "Symbol",
   t: "Timestamp",
@@ -346,6 +426,14 @@ export function AlpacaStatusV2(data: RawStatus): AlpacaStatus {
 
 export function AlpacaLuldV2(data: RawLuld): AlpacaLuld {
   return aliasObjectKey(data, luld_mapping_v2) as AlpacaLuld;
+}
+
+export function AlpacaCancelErrorV2(data: RawCancelError): AlpacaCancelError {
+  return aliasObjectKey(data, cancel_error_mapping_v2) as AlpacaCancelError;
+}
+
+export function AlpacaCorrectionV2(data: RawCorrection): AlpacaCorrection {
+  return aliasObjectKey(data, correction_mapping_v2) as AlpacaCorrection;
 }
 
 export function AlpacaCryptoTrade(data: RawCryptoTrade): CryptoTrade {

--- a/lib/resources/datav2/websocket.ts
+++ b/lib/resources/datav2/websocket.ts
@@ -27,6 +27,8 @@ export enum EVENT {
   DAILY_BARS = "stock_daily_bars",
   TRADING_STATUSES = "trading_statuses",
   LULDS = "lulds",
+  CANCEL_ERRORS = "cancel_errors",
+  CORRECTIONS = "corrections",
 }
 
 // Connection errors by code

--- a/test/streaming-v2.test.js
+++ b/test/streaming-v2.test.js
@@ -93,6 +93,8 @@ describe("data_stream_v2", () => {
       dailyBars: [],
       statuses: [],
       lulds: [],
+      cancelErrors: [],
+      corrections: [],
     };
 
     socket.subscribeForTrades(["AAPL"]);
@@ -112,6 +114,8 @@ describe("data_stream_v2", () => {
       dailyBars: [],
       statuses: [],
       lulds: [],
+      cancelErrors: [],
+      corrections: [],
     };
 
     socket.unsubscribeFromTrades("AAPL");

--- a/test/streaming-v2.test.js
+++ b/test/streaming-v2.test.js
@@ -93,8 +93,8 @@ describe("data_stream_v2", () => {
       dailyBars: [],
       statuses: [],
       lulds: [],
-      cancelErrors: [],
-      corrections: [],
+      cancelErrors: ["AAPL"],
+      corrections: ["AAPL"],
     };
 
     socket.subscribeForTrades(["AAPL"]);

--- a/test/support/mock-streaming.js
+++ b/test/support/mock-streaming.js
@@ -92,6 +92,8 @@ class StreamingWsMock {
       dailyBars: [],
       statuses: [],
       lulds: [],
+      cancelErrors: [],
+      corrections: [],
     };
   }
 
@@ -194,6 +196,8 @@ class StreamingWsMock {
         dailyBars: this.subscriptions.dailyBars,
         statuses: this.subscriptions.statuses,
         lulds: this.subscriptions.lulds,
+        cancelErrors: this.subscriptions.trades,  // Subscribed automatically.
+        corrections: this.subscriptions.trades, // // Subscribed automatically.
       },
     ];
   }


### PR DESCRIPTION
## Context
Handle trade cancel errors and trade corrections messages. Users can now call things like:
```
socket.onCancelErrors((tce) => {
  console.log(tce);
});

socket.onCorrections((tc) => {
  console.log(tc);
});
```
## TODO
- ~Double check test coverage~

## Test results
```
{
  T: 'c',
  Symbol: 'BAC',
  Exchange: 'M',
  OriginalID: 52983525097785,
  OriginalPrice: 44.54,
  OriginalSize: 3817,
  OriginalConditions: [ ' ', '7' ],
  CorrectedID: 52983525098568,
  CorrectedPrice: 44.54,
  CorrectedSize: 297726,
  CorrectedConditions: [ ' ', '7' ],
  Tape: 'A',
  Timestamp: 2021-12-07T19:26:34.561Z
}
{
  T: 'x',
  Symbol: 'RCL',
  ID: 71684334236466,
  Exchange: 'D',
  Price: 73.28,
  Size: 20100,
  CancelErrorAction: 'C',
  Tape: 'A',
  Timestamp: 2021-12-07T17:46:38.024Z
}
```