### PR TITLE
Added method to get crypto snapshot

### DIFF
--- a/lib/alpaca-trade-api.js
+++ b/lib/alpaca-trade-api.js
@@ -195,6 +195,9 @@ class Alpaca {
   getLatestCryptoXBBO(symbol, options, config = this.configuration) {
     return dataV2.getLatestCryptoXBBO(symbol, options, config);
   }
+  getCryptoSnapshot(symbol, options, config = this.configuration) {
+    return dataV2.getCryptoSnapshot(symbol, options, config);
+  }
 
   // Watchlists
   getWatchlists = watchlist.getAll;

--- a/lib/resources/datav2/entityv2.ts
+++ b/lib/resources/datav2/entityv2.ts
@@ -249,7 +249,7 @@ export interface RawCryptoQuote {
   as: number;
 }
 
-const crypro_bar_mapping = {
+const crypto_bar_mapping = {
   S: "Symbol",
   t: "Timestamp",
   o: "Open",
@@ -320,6 +320,22 @@ export interface RawCryptoXBBO {
   as: number;
 }
 
+const crypto_snapshot_mapping = {
+  latestTrade: "LatestTrade",
+  latestQuote: "LatestQuote",
+  minuteBar: "MinuteBar",
+  dailyBar: "DailyBar",
+  prevDailyBar: "PrevDailyBar",
+};
+
+export interface CryptoSnapshot {
+  LatestTrade: CryptoTrade;
+  LatestQuote: CryptoQuote;
+  MinuteBar: CryptoBar;
+  DailyBar: CryptoBar;
+  PrevDailyBar: CryptoBar;
+}
+
 export function AlpacaTradeV2(data: RawTrade): AlpacaTrade {
   return aliasObjectKey(data, trade_mapping_v2) as AlpacaTrade;
 }
@@ -332,7 +348,7 @@ export function AlpacaBarV2(data: RawBar): AlpacaBar {
   return aliasObjectKey(data, bar_mapping_v2) as AlpacaBar;
 }
 
-export function AlpacaSnapshotV2(data: AlpacaStatus): AlpacaSnapshot {
+export function AlpacaSnapshotV2(data: any): AlpacaSnapshot {
   const snapshot = aliasObjectKey(data, snapshot_mapping_v2);
 
   return mapValues(snapshot, (value: any, key: any) => {
@@ -357,7 +373,15 @@ export function AlpacaCryptoQuote(data: RawCryptoQuote): CryptoQuote {
 }
 
 export function AlpacaCryptoBar(data: RawCryptoBar): CryptoBar {
-  return aliasObjectKey(data, crypro_bar_mapping) as CryptoBar;
+  return aliasObjectKey(data, crypto_bar_mapping) as CryptoBar;
+}
+
+export function AlpacaCryptoSnapshot(data: any): CryptoSnapshot {
+  const snapshot = aliasObjectKey(data, crypto_snapshot_mapping);
+
+  return mapValues(snapshot, (value: any, key: any) => {
+    return convertCryptoSnapshotData(key, value);
+  }) as CryptoSnapshot;
 }
 
 function aliasObjectKey(data: any, mapping: any) {
@@ -380,6 +404,21 @@ function convertSnapshotData(key: string, data: any) {
     case "DailyBar":
     case "PrevDailyBar":
       return AlpacaBarV2(data);
+    default:
+      return data;
+  }
+}
+
+function convertCryptoSnapshotData(key: string, data: any) {
+  switch (key) {
+    case "LatestTrade":
+      return AlpacaCryptoTrade(data);
+    case "LatestQuote":
+      return AlpacaCryptoQuote(data);
+    case "MinuteBar":
+    case "DailyBar":
+    case "PrevDailyBar":
+      return AlpacaCryptoBar(data);
     default:
       return data;
   }

--- a/lib/resources/datav2/entityv2.ts
+++ b/lib/resources/datav2/entityv2.ts
@@ -252,6 +252,7 @@ export interface RawCryptoQuote {
 const crypto_bar_mapping = {
   S: "Symbol",
   t: "Timestamp",
+  x: "Exchange",
   o: "Open",
   h: "High",
   l: "Low",

--- a/lib/resources/datav2/entityv2.ts
+++ b/lib/resources/datav2/entityv2.ts
@@ -353,7 +353,7 @@ export function AlpacaSnapshotV2(data: any): AlpacaSnapshot {
   const snapshot = aliasObjectKey(data, snapshot_mapping_v2);
 
   return mapValues(snapshot, (value: any, key: any) => {
-    return convertSnapshotData(key, value);
+    return convertSnapshotData(key, value, false);
   }) as AlpacaSnapshot;
 }
 
@@ -381,7 +381,7 @@ export function AlpacaCryptoSnapshot(data: any): CryptoSnapshot {
   const snapshot = aliasObjectKey(data, crypto_snapshot_mapping);
 
   return mapValues(snapshot, (value: any, key: any) => {
-    return convertCryptoSnapshotData(key, value);
+    return convertSnapshotData(key, value, true);
   }) as CryptoSnapshot;
 }
 
@@ -395,31 +395,16 @@ export function AlpacaCryptoXBBO(data: RawCryptoXBBO): CryptoXBBO {
   return aliasObjectKey(data, crypto_xbbo_mapping) as CryptoXBBO;
 }
 
-function convertSnapshotData(key: string, data: any) {
+function convertSnapshotData(key: string, data: any, isCrypto: boolean) {
   switch (key) {
     case "LatestTrade":
-      return AlpacaTradeV2(data);
+      return isCrypto ? AlpacaCryptoTrade(data) : AlpacaTradeV2(data);
     case "LatestQuote":
-      return AlpacaQuoteV2(data);
+      return isCrypto ? AlpacaCryptoQuote(data) : AlpacaQuoteV2(data);
     case "MinuteBar":
     case "DailyBar":
     case "PrevDailyBar":
-      return AlpacaBarV2(data);
-    default:
-      return data;
-  }
-}
-
-function convertCryptoSnapshotData(key: string, data: any) {
-  switch (key) {
-    case "LatestTrade":
-      return AlpacaCryptoTrade(data);
-    case "LatestQuote":
-      return AlpacaCryptoQuote(data);
-    case "MinuteBar":
-    case "DailyBar":
-    case "PrevDailyBar":
-      return AlpacaCryptoBar(data);
+      return isCrypto ? AlpacaCryptoBar(data) : AlpacaBarV2(data);
     default:
       return data;
   }

--- a/lib/resources/datav2/rest_v2.ts
+++ b/lib/resources/datav2/rest_v2.ts
@@ -12,10 +12,12 @@ import {
   CryptoQuote,
   CryptoTrade,
   CryptoBar,
+  CryptoSnapshot,
   AlpacaSnapshot,
   AlpacaQuote,
   AlpacaTrade,
   AlpacaBar,
+  AlpacaCryptoSnapshot,
 } from "./entityv2";
 
 // Number of data points to return.
@@ -522,4 +524,18 @@ export async function getLatestCryptoXBBO(
     config
   );
   return AlpacaCryptoXBBO({ S: resp.data.symbol, ...resp.data.xbbo });
+}
+
+export async function getCryptoSnapshot(
+  symbol: string,
+  options: { exchange: string },
+  config: any
+): Promise<CryptoSnapshot> {
+  const resp = await dataV2HttpRequest(
+    `/v1beta1/crypto/${symbol}/snapshot`,
+    options,
+    config
+  );
+
+  return AlpacaCryptoSnapshot(resp.data);
 }

--- a/test/rest_v2.test.js
+++ b/test/rest_v2.test.js
@@ -14,9 +14,16 @@ const tradeKeys = [
   "Tape",
 ];
 
-function assertTrade(trade, keys = tradeKeys) {
-  expect(trade).to.have.all.keys(keys);
-}
+const quoteKeys = [
+  "BidExchange",
+  "BidPrice",
+  "BidSize",
+  "AskExchange",
+  "AskPrice",
+  "AskSize",
+  "Timestamp",
+  "Conditions",
+];
 
 const barKeys = [
   "OpenPrice",
@@ -29,23 +36,16 @@ const barKeys = [
   "VWAP",
 ];
 
-function assertBar(bar, keys = barKeys) {
-  expect(bar).to.have.all.keys(keys);
+function assertTrade(trade, keys = tradeKeys) {
+  expect(trade).to.have.all.keys(keys);
 }
-
-const quoteKeys = [
-  "BidExchange",
-  "BidPrice",
-  "BidSize",
-  "AskExchange",
-  "AskPrice",
-  "AskSize",
-  "Timestamp",
-  "Conditions",
-];
 
 function assertQuote(quote, keys = quoteKeys) {
   expect(quote).to.have.all.keys(keys);
+}
+
+function assertBar(bar, keys = barKeys) {
+  expect(bar).to.have.all.keys(keys);
 }
 
 function assertSnapshot(snapshot) {
@@ -229,28 +229,46 @@ describe("data v2 rest", () => {
   });
 });
 
-function assertCryptoQuote(quote) {
-  expect(quote).to.have.all.keys([
-    "Symbol",
-    "Timestamp",
-    "Exchange",
-    "BidPrice",
-    "BidSize",
-    "AskPrice",
-    "AskSize",
-  ]);
+const cryptoTradeKeys = [
+  "Timestamp",
+  "Exchange",
+  "Price",
+  "Size",
+  "TakerSide",
+  "ID",
+];
+
+const cryptoQuoteKeys = [
+  "Timestamp",
+  "Exchange",
+  "BidPrice",
+  "BidSize",
+  "AskPrice",
+  "AskSize",
+];
+
+const cryptoBarKeys = [
+  "Timestamp",
+  "Exchange",
+  "Open",
+  "High",
+  "Low",
+  "Close",
+  "Volume",
+  "VWAP",
+  "TradeCount",
+];
+
+function assertCryptoTrade(trade, keys = cryptoTradeKeys) {
+  expect(trade).to.have.all.keys(keys);
 }
 
-function assertCryptoTrade(trade) {
-  expect(trade).to.have.all.keys([
-    "Symbol",
-    "Timestamp",
-    "Exchange",
-    "Price",
-    "Size",
-    "TakerSide",
-    "ID",
-  ]);
+function assertCryptoQuote(quote, keys = cryptoQuoteKeys) {
+  expect(quote).to.have.all.keys(keys);
+}
+
+function assertCryptoBar(bar, keys = cryptoBarKeys) {
+  expect(bar).to.have.all.keys(keys);
 }
 
 function assertCryptoXBBO(xbbo) {
@@ -266,12 +284,36 @@ function assertCryptoXBBO(xbbo) {
   ]);
 }
 
+function assertCryptoSnapshot(snapshot) {
+  expect(snapshot).to.have.all.keys([
+    "symbol",
+    "LatestTrade",
+    "LatestQuote",
+    "MinuteBar",
+    "DailyBar",
+    "PrevDailyBar",
+  ]);
+  assertCryptoTrade(snapshot.LatestTrade);
+  assertCryptoQuote(snapshot.LatestQuote);
+  assertCryptoBar(snapshot.MinuteBar);
+  assertCryptoBar(snapshot.DailyBar);
+  assertCryptoBar(snapshot.PrevDailyBar);
+}
+
 describe("crypto data", () => {
   let alpaca;
 
   before(() => {
     alpaca = new api(mock.getConfig());
   });
+  
+    it("get latest trade", async () => {
+      const resp = await alpaca.getLatestCryptoTrade("BTCUSD", {
+        exchange: "ERSX",
+      });
+  
+      assertCryptoTrade(resp, ["Symbol", ...cryptoTradeKeys]);
+    });
 
   it("get quotes", async () => {
     const resp = alpaca.getCryptoQuotes("BTCUSD", {
@@ -285,17 +327,9 @@ describe("crypto data", () => {
 
     for await (let q of resp) {
       quotes.push(q);
-      assertCryptoQuote(q);
+      assertCryptoQuote(q, ["Symbol", ...cryptoQuoteKeys]);
     }
     expect(quotes.length).equal(3);
-  });
-
-  it("get latest trade", async () => {
-    const resp = await alpaca.getLatestCryptoTrade("BTCUSD", {
-      exchange: "ERSX",
-    });
-
-    assertCryptoTrade(resp);
   });
 
   it("get latest xbbo", async () => {
@@ -304,5 +338,12 @@ describe("crypto data", () => {
     });
 
     assertCryptoXBBO(resp);
+  });
+
+  it("get snapshot for one symbol", async () => {
+    const resp = await alpaca.getCryptoSnapshot("BTCUSD", {
+      exchange: "ERSX"
+    });
+    assertCryptoSnapshot(resp);
   });
 });

--- a/test/support/mock-crypto-data.js
+++ b/test/support/mock-crypto-data.js
@@ -29,10 +29,7 @@ module.exports = function createCryptoDataMock() {
   v1beta1.get(
     "/crypto/:symbol/snapshot",
     apiMethod((req) => {
-      if (req.params.symbol == null) {
-        throw apiError(422);
-      }
-      if (req.query.exchange == null) {
+      if (req.params.symbol == null || req.query.exchange == null) {
         throw apiError(422);
       }
       return { ...snapshots[req.params.symbol][req.query.exchange] };

--- a/test/support/mock-crypto-data.js
+++ b/test/support/mock-crypto-data.js
@@ -27,6 +27,19 @@ module.exports = function createCryptoDataMock() {
   });
 
   v1beta1.get(
+    "/crypto/:symbol/snapshot",
+    apiMethod((req) => {
+      if (req.params.symbol == null) {
+        throw apiError(422);
+      }
+      if (req.query.exchange == null) {
+        throw apiError(422);
+      }
+      return { ...snapshots[req.params.symbol][req.query.exchange] };
+    })
+  );
+
+  v1beta1.get(
     "/crypto/:symbol/:endpoint",
     apiMethod((req) => {
       assertSchema(req.query, {
@@ -126,3 +139,60 @@ const latestDataBySymbol = {
     },
   },
 };
+
+const snapshots = {
+  BTCUSD: {
+    ERSX: {
+      symbol: "BTCUSD",
+      latestTrade: {
+          t: "2021-12-09T15:07:13.573434454Z",
+          x: "ERSX",
+          p: 48714.5,
+          s: 0.0205,
+          tks: "B",
+          i: 0
+      },
+      latestQuote: {
+          t: "2021-12-09T15:08:33.405330416Z",
+          x: "ERSX",
+          bp: 48738.9,
+          bs: 1.5388,
+          ap: 48759,
+          as: 1.5382
+      },
+      minuteBar: {
+          t: "2021-12-09T15:07:00Z",
+          x: "ERSX",
+          o: 48714.5,
+          h: 48714.5,
+          l: 48714.5,
+          c: 48714.5,
+          v: 0.0205,
+          n: 1,
+          vw: 48714.5
+      },
+      dailyBar: {
+          t: "2021-12-09T06:00:00Z",
+          x: "ERSX",
+          o: 49838,
+          h: 50310.5,
+          l: 48361.3,
+          c: 48714.5,
+          v: 305.0539,
+          n: 215,
+          vw: 49176.7255476491
+      },
+      prevDailyBar: {
+          t: "2021-12-08T06:00:00Z",
+          x: "ERSX",
+          o: 50692,
+          h: 51269,
+          l: 48734.2,
+          c: 49883.4,
+          v: 481.7121,
+          n: 476,
+          vw: 50083.3525751792
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Context
Add method for user to query crypto snapshot, which would look something like this:
```
resp = await alpaca.getCryptoSnapshot("ETHUSD", {exchange: "CBSE"});
console.log(resp)
```

## TODO
- ~Add unit test~

## Notes
Other than adding the method and unit test, I think I saw `crypto_bar_mapping` was missing the exchange field, so I added it.

## Test results
```
{
  symbol: 'ETHUSD',
  LatestTrade: {
    Timestamp: '2021-12-08T19:26:58.703892Z',
    Exchange: 'CBSE',
    Price: 4393.18,
    Size: 0.04299154,
    TakerSide: 'S',
    ID: 191026243
  },
  LatestQuote: {
    Timestamp: '2021-12-09T17:50:50.488Z',
    Exchange: 'CBSE',
    BidPrice: 4189.98,
    BidSize: 0.12914967,
    AskPrice: 4189.99,
    AskSize: 1.45300176
  },
  MinuteBar: {
    Timestamp: '2021-12-08T19:26:00Z',
    Exchange: 'CBSE',
    Open: 4393.62,
    High: 4396.45,
    Low: 4390.81,
    Close: 4393.18,
    Volume: 132.02049802,
    TradeCount: 278,
    VWAP: 4393.9907155981
  },
  DailyBar: {
    Timestamp: '2021-12-08T06:00:00Z',
    Exchange: 'CBSE',
    Open: 4329.11,
    High: 4455.62,
    Low: 4231.55,
    Close: 4393.18,
    Volume: 95466.0903448,
    TradeCount: 186155,
    VWAP: 4367.7642299555
  },
  PrevDailyBar: {
    Timestamp: '2021-12-07T06:00:00Z',
    Exchange: 'CBSE',
    Open: 4350.15,
    High: 4433.99,
    Low: 4261.39,
    Close: 4329.11,
    Volume: 152391.30635034,
    TradeCount: 326203,
    VWAP: 4344.2956259855
  }
}
```