### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ getBarsV2(
     end: date isoformat string yyyy-mm-ddThh:MM:ss-04:00,
     timeframe: "1Min" | "1Hour" | "1Day"
   }
-) => Promise<BarsObject>
+) => AsyncGenerator<AlpacaBar, void, unknown>
 ```
 ###### example
 ```js


### PR DESCRIPTION
I think it's more clear writing the exact type of getBarsV2 return value: `AsyncGenerator<AlpacaBar, void, unknown>` or `AsyncGenerator<BarsObject, void, unknown>` will be good solutions. 
`Promise<BarsObject>` it's definitely wrong and confusing.