### PR TITLE
Added missing Exchange prop to CryptoBar interface

### DIFF
--- a/lib/resources/datav2/entityv2.ts
+++ b/lib/resources/datav2/entityv2.ts
@@ -345,6 +345,7 @@ const crypto_bar_mapping = {
 export interface CryptoBar {
   Symbol: string;
   Timestamp: string;
+  Exchange: string;
   Open: number;
   High: number;
   Low: number;


### PR DESCRIPTION
The CryptoBar interface is missing the Exchange property which leads to errors when working with Typescript.