### PR TITLE
Add tools/ directory to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,4 +2,5 @@
 test/
 lib/
 .circleci/
+tools/
 .env.example


### PR DESCRIPTION
This PR is aimed to remove `tools` directory from npm artifact. Current files structure looks like:
<img width="245" alt="image" src="https://user-images.githubusercontent.com/7945837/178809094-abdcb9b5-200a-4fc0-9219-7af013306e1b.png">

Definitely that `tools` directory is redundant for target users of the library.