### PR TITLE
Move credential check to connect in websocket 

### DIFF
--- a/lib/resources/datav2/websocket.ts
+++ b/lib/resources/datav2/websocket.ts
@@ -135,13 +135,6 @@ export abstract class AlpacaWebsocket
       pongWait: 5000,
     };
 
-    if (this.session.apiKey.length === 0) {
-      throw new Error(ERROR.MISSING_API_KEY);
-    }
-    if (this.session.secretKey.length === 0) {
-      throw new Error(ERROR.MISSING_SECERT_KEY);
-    }
-
     // Register internal event handlers
     // Log and emit every state change
     Object.values(STATE).forEach((s) => {
@@ -154,6 +147,13 @@ export abstract class AlpacaWebsocket
   connect(): void {
     this.emit(STATE.CONNECTING);
     this.session.currentState = STATE.CONNECTING;
+    // Check the credentials
+    if (this.session.apiKey.length === 0) {
+      throw new Error(ERROR.MISSING_API_KEY);
+    }
+    if (this.session.secretKey.length === 0) {
+      throw new Error(ERROR.MISSING_SECERT_KEY);
+    }
     this.resetSession();
     this.conn = new WebSocket(this.session.url, {
       perMessageDeflate: {

--- a/lib/resources/websockets.js
+++ b/lib/resources/websockets.js
@@ -75,15 +75,6 @@ class AlpacaStreamClient extends events.EventEmitter {
     this.session = Object.assign(this.defaultOptions, opts);
 
     this.session.url = this.session.url.replace(/^http/, "ws") + "/stream";
-    if (this.session.apiKey.length === 0 && this.session.oauth.length === 0) {
-      throw new Error(ERROR.MISSING_API_KEY);
-    }
-    if (
-      this.session.secretKey.length === 0 &&
-      this.session.oauth.length === 0
-    ) {
-      throw new Error(ERROR.MISSING_SECRET_KEY);
-    }
     // Keep track of subscriptions in case we need to reconnect after the client
     // has called subscribe()
     this.subscriptionState = {};
@@ -110,6 +101,13 @@ class AlpacaStreamClient extends events.EventEmitter {
   }
 
   connect() {
+    // Check the credentials
+    if (this.session.apiKey.length === 0 && this.session.oauth.length === 0) {
+      throw new Error(ERROR.MISSING_API_KEY);
+    }
+    if (this.session.secretKey.length === 0 && this.session.oauth.length === 0) {
+      throw new Error(ERROR.MISSING_SECRET_KEY);
+    }
     // Reset reconnectDisabled since the user called connect() again
     this.reconnectDisabled = false;
     this.emit(STATE.CONNECTING);
@@ -198,9 +196,7 @@ class AlpacaStreamClient extends events.EventEmitter {
     // if the user unsubscribes from certain equities, they will still be
     // under this.subscriptionState but with value "false", so we need to
     // filter them out
-    return Object.keys(this.subscriptionState).filter(
-      (x) => this.subscriptionState[x]
-    );
+    return Object.keys(this.subscriptionState).filter((x) => this.subscriptionState[x]);
   }
 
   onConnect(fn) {
@@ -349,23 +345,11 @@ class AlpacaStreamClient extends events.EventEmitter {
         break;
       default:
         if (message.stream.startsWith("T.")) {
-          this.emit(
-            EVENT.STOCK_TRADES,
-            subject,
-            entity.AlpacaTrade(message.data)
-          );
+          this.emit(EVENT.STOCK_TRADES, subject, entity.AlpacaTrade(message.data));
         } else if (message.stream.startsWith("Q.")) {
-          this.emit(
-            EVENT.STOCK_QUOTES,
-            subject,
-            entity.AlpacaQuote(message.data)
-          );
+          this.emit(EVENT.STOCK_QUOTES, subject, entity.AlpacaQuote(message.data));
         } else if (message.stream.startsWith("AM.")) {
-          this.emit(
-            EVENT.STOCK_AGG_MIN,
-            subject,
-            entity.AggMinuteBar(message.data)
-          );
+          this.emit(EVENT.STOCK_AGG_MIN, subject, entity.AggMinuteBar(message.data));
         } else {
           this.emit(ERROR.PROTOBUF);
         }


### PR DESCRIPTION
The historical crypto data is available without authentication but the Alpaca object could only be initialised if the user set the credentials. This PR fixes this, now you can create an Alpaca object without getting a missing API key/secret error if not set. 