### PR TITLE
fix typo

### DIFF
--- a/lib/resources/datav2/entityv2.ts
+++ b/lib/resources/datav2/entityv2.ts
@@ -575,7 +575,7 @@ export interface AlpacaOptionSnapshot {
   Symbol: string;
   LatestTrade: AlpacaTrade;
   LatestQuote: AlpacaQuote;
-  ImpliedVOlatility: number;
+  ImpliedVolatility: number;
   Greeks: Greeks;
 }
 


### PR DESCRIPTION
`ImpliedVOlatility` does not match the name the field is mapped to in option_snapshot_mapping (`ImpliedVolatility `)