### PR TITLE
Improve error handling in REST API calls

### DIFF
--- a/lib/resources/datav2/rest_v2.ts
+++ b/lib/resources/datav2/rest_v2.ts
@@ -75,11 +75,15 @@ export function dataV2HttpRequest(
       headers: headers,
     })
     .catch((err: any) => {
-      throw new Error(
-        `code: ${err.response?.status || err.statusCode}, message: ${
-          err.response?.data.message
-        }`
-      );
+      if (err.response) {
+        throw new Error(
+          `code: ${err.response.status}, message: ${
+            err.response.data?.message
+          }`
+        );
+      }
+
+      throw new err;
     });
 }
 


### PR DESCRIPTION
This improves error logging when there is no `response` on the Error object.

```
try {
  await alpaca.getLatestTrade('OKLL');
} catch (error) {
  console.error(`Error getting latest trade:`, error.message, JSON.stringify(error));
}
```

Before:
```
Error getting latest trade: code: undefined, message: undefined {}
```

After:
```
Error getting latest trade: connect ETIMEDOUT 34.86.145.125:443 {"message":"connect ETIMEDOUT 34.86.145.125:443","name":"Error","stack":"Error: connect ETIMEDOUT 34.86.145.125:443\n    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16)","config":{"url":"https://data.alpaca.markets/v2/stocks/OKLL/trades/latest","method":"get","headers":{"Accept":"application/json, text/plain, */*","Content-Type":"application/json","Accept-Encoding":"gzip","APCA-API-KEY-ID":"xxx","APCA-API-SECRET-KEY":"xxx","User-Agent":"axios/0.21.4"},"params":{},"transformRequest":[null],"transformResponse":[null],"timeout":0,"xsrfCookieName":"XSRF-TOKEN","xsrfHeaderName":"X-XSRF-TOKEN","maxContentLength":-1,"maxBodyLength":-1,"transitional":{"silentJSONParsing":true,"forcedJSONParsing":true,"clarifyTimeoutError":false}},"code":"ETIMEDOUT"}
```
