### PR TITLE
fix: surface the crypto trade taker side (tks) on stream trades

### DIFF
--- a/.changeset/stream-trade-taker-side.md
+++ b/.changeset/stream-trade-taker-side.md
@@ -1,0 +1,5 @@
+---
+"@alpacahq/alpaca-trade-api": patch
+---
+
+Surface the crypto trade taker side on stream trades: `mapTrade` now maps the wire's `tks` field to `StreamTrade.takerSide` ("B"/"S", crypto only). Previously the field was dropped by the stream mapper even though the v1beta3 crypto stream delivers it and the REST `CryptoTrade` path already exposed it.

--- a/docs/docs/streaming.md
+++ b/docs/docs/streaming.md
@@ -70,6 +70,18 @@ the same `idRaw`, so ids you backfill over REST match the ones you receive live
 — see [Trade-id precision](./market-data.md#trade-id-precision) in the
 market-data guide.
 
+## Crypto taker side
+
+Crypto trades carry the aggressor side — who crossed the spread to make the
+trade happen:
+
+- `takerSide?: string` — `"B"` (buyer-initiated) or `"S"` (seller-initiated).
+
+Crypto only: equities trade messages carry no taker side on the wire, so the
+field stays `undefined` there. The REST canonical accessor (`getCryptoTrades`)
+exposes the same field, so taker sides you backfill over REST match the ones
+you receive live.
+
 ## Shared lifecycle
 
 Every stream exposes:

--- a/src/streaming/types.ts
+++ b/src/streaming/types.ts
@@ -80,6 +80,8 @@ export interface RawTrade {
     t: unknown;
     c?: string[];
     z?: string;
+    /** Taker side ("B" buyer / "S" seller). Crypto trades only. */
+    tks?: string;
 }
 
 /**
@@ -107,6 +109,7 @@ export function mapTrade(raw: RawTrade): StreamTrade {
         timestampRaw: toRawTs(raw.t),
         conditions: raw.c ?? [],
         tape: raw.z,
+        takerSide: raw.tks,
     };
 }
 

--- a/test/streaming.test.ts
+++ b/test/streaming.test.ts
@@ -226,6 +226,34 @@ describe('StockDataStream (market data)', () => {
         expect(bars[0].volume).toBe(9_007_199_254_740_992);
     });
 
+    it('surfaces the crypto taker side (tks) as takerSide, absent on equities trades', () => {
+        const sock = new FakeSocket();
+        const stream = new streaming.CryptoDataStream({
+            credentials: CREDS,
+            pingIntervalMs: 0,
+            wsFactory: () => sock,
+        });
+        const trades: streaming.StreamTrade[] = [];
+        stream.onTrade((t) => trades.push(t));
+        stream.connect();
+        authenticateMd(sock);
+
+        const ts = new Date('2026-01-02T15:04:05Z');
+        sock.emitEvent(
+            'message',
+            mpEncode([
+                // Crypto trade wire shape per the real-time crypto docs: tks present.
+                { T: 't', S: 'AVAX/USD', i: 42, p: 47.299, s: 29.205707815, t: ts, tks: 'S' },
+                // Equities-shaped trade: no tks on the wire -> no takerSide mapped.
+                { T: 't', S: 'BTC/USD', i: 43, x: 'V', p: 187.25, s: 100, t: ts, c: ['@'], z: 'C' },
+            ]),
+        );
+
+        expect(trades).toHaveLength(2);
+        expect(trades[0].takerSide).toBe('S');
+        expect(trades[1].takerSide).toBeUndefined();
+    });
+
     it('maps numeric error codes to messages', () => {
         const sock = new FakeSocket();
         const stream = new streaming.StockDataStream({


### PR DESCRIPTION
The v1beta3 crypto stream delivers tks (taker side, "B"/"S") on every trade message, and the canonical Trade type already declares takerSide — but the stream mapper never connected them: RawTrade didn't model tks and mapTrade builds the StreamTrade field-by-field, so the value was silently dropped. The REST path (toCryptoTrade in marketDataShapes.ts) has mapped it all along, so REST and stream trades disagreed about a field the wire provides to both.

This maps tks → StreamTrade.takerSide in mapTrade, mirroring the REST behavior. Equities trades carry no tks, so takerSide remains undefined there — covered by the added test alongside the crypto case (fixture shape from the [real-time crypto docs](https://docs.alpaca.markets/us/docs/real-time-crypto-pricing-data)). Changeset included (patch).

This pull request adds support for surfacing the crypto trade taker side on stream trades. The main change is that the `mapTrade` function now maps the wire's `tks` field to the `StreamTrade.takerSide` property, making the aggressor side (buyer or seller) available for crypto trades in the streaming API. Documentation and tests have also been updated to reflect this new field.

**Streaming API enhancements:**

* [`src/streaming/types.ts`](diffhunk://#diff-fcdae63629e7ab992da11cef21befaa93743f7598d4280809df7610366d33c6fR83-R84): The `RawTrade` interface now includes an optional `tks` field for the taker side, and `mapTrade` maps this to the new `takerSide` property on `StreamTrade`. [[1]](diffhunk://#diff-fcdae63629e7ab992da11cef21befaa93743f7598d4280809df7610366d33c6fR83-R84) [[2]](diffhunk://#diff-fcdae63629e7ab992da11cef21befaa93743f7598d4280809df7610366d33c6fR112)

**Documentation updates:**

* [`docs/docs/streaming.md`](diffhunk://#diff-a9a1734c4ffab61b861d9953034b9494e3b491dcdda3dd603e27623fb43aa027R73-R84): Added a section describing the new `takerSide` field for crypto trades, clarifying its meaning and that it is not present for equities.

**Testing:**

* [`test/streaming.test.ts`](diffhunk://#diff-d60ebae46a9d6b9c74a25155c5aecc9be105db1094fcd815c7efd022e35b4e0aR229-R256): Added a test to verify that the `takerSide` is surfaced for crypto trades and absent for equities trades.

**Release notes:**

* [`.changeset/stream-trade-taker-side.md`](diffhunk://#diff-13e74886a55fab5323ffd5de06178d0bd588c077d393d5b933c764f053f8cea5R1-R5): Added a changeset entry describing the new `takerSide` field on stream trades for crypto.