### PR TITLE
fix: allow Changesets release PRs through CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,13 +27,20 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
-      # Pull request checkouts do not create a local base branch, but Changesets
-      # resolves `baseBranch: master` through that local ref.
-      - name: Expose base branch to Changesets
-        if: github.event_name == 'pull_request'
-        run: git show-ref --verify --quiet refs/heads/master || git branch master origin/master
-      - name: Verify Changesets configuration
-        run: npm exec -- changeset status
+      - name: Verify pending Changesets
+        run: |
+          pending_changesets="$(git ls-files -- '.changeset/*.md' ':(exclude).changeset/README.md')"
+          if [[ -z "$pending_changesets" ]]; then
+            echo "No pending Changesets to validate."
+            exit 0
+          fi
+
+          # Pull request checkouts do not create a local base branch, but
+          # Changesets resolves `baseBranch: master` through that local ref.
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            git show-ref --verify --quiet refs/heads/master || git branch master origin/master
+          fi
+          npm exec -- changeset status
       - name: Typecheck
         run: npm run typecheck
       - name: Lint


### PR DESCRIPTION
## What

Allow CI to skip Changesets status validation when there are no pending changeset files.

## Why

Changesets-generated release PRs consume their pending changesets before opening or updating the release branch. The unconditional status check therefore rejected the valid [4.0.2 release PR](https://github.com/alpacahq/alpaca-trade-api-js/pull/317) before lint, tests, or build could run.

## Changes

- Detect tracked changeset Markdown files while excluding `.changeset/README.md`.
- Exit successfully when no pending changesets need validation, covering generated release PRs and internal-only changes.
- Preserve full Changesets validation and local base-branch setup whenever pending changesets exist.

## Checklist

- [x] Pending-changeset validation path passes.
- [x] Empty-changeset release path exits successfully.
- [x] Workflow YAML and shell syntax validated.
- [x] No SDK source, generated output, package metadata, or runtime behavior changed.

Made with [Cursor](https://cursor.com)